### PR TITLE
fix action loop being triggered with display-only monsters

### DIFF
--- a/src/main/java/ludicrousspeed/LudicrousSpeedMod.java
+++ b/src/main/java/ludicrousspeed/LudicrousSpeedMod.java
@@ -25,7 +25,9 @@ public class LudicrousSpeedMod implements PreUpdateSubscriber {
 
     @Override
     public void receivePreUpdate() {
-        if (AbstractDungeon.currMapNode != null && AbstractDungeon.getCurrRoom().monsters != null) {
+        // some event screens display monsters without it being combat
+        if (AbstractDungeon.currMapNode != null && AbstractDungeon.getCurrRoom().monsters != null 
+                && AbstractDungeon.getCurrRoom().phase != AbstractRoom.RoomPhase.EVENT) {
             if (LudicrousSpeedMod.plaidMode) {
                 ActionSimulator.actionLoop();
             } else if (shouldNormalUpdate()) {


### PR DESCRIPTION
example: Mushrooms event displays rodents before they are available to fight. we don't want to trigger into the action loop as long as we are not in actual combat...