### PR TITLE
fix relic name not being set in Relic patch

### DIFF
--- a/src/main/java/ludicrousspeed/simulator/patches/RelicPatches.java
+++ b/src/main/java/ludicrousspeed/simulator/patches/RelicPatches.java
@@ -44,8 +44,9 @@ public class RelicPatches {
         @SpireInsertPatch(loc = 127)
         public static SpireReturn Insert(AbstractRelic _instance, String setId, String imgName, AbstractRelic.RelicTier tier, AbstractRelic.LandingSound sfx) {
             if (LudicrousSpeedMod.plaidMode) {
-                // we need to set the tier field to avoid NPE
+                // we need to set these fields to avoid NPE
                 _instance.tier = tier;
+                _instance.name = _instance.relicStrings.NAME;
                 return SpireReturn.Return(null);
             }
             return SpireReturn.Continue();


### PR DESCRIPTION
Example of another mod expecting relic.name to not be null: https://github.com/ForgottenArbiter/CommunicationMod/blob/5e417eb189530986b9047a3c9426889fb261d146/src/main/java/communicationmod/ChoiceScreenUtils.java#L532